### PR TITLE
Link to react-intersection-observer

### DIFF
--- a/src/pages/useOnScreen.md
+++ b/src/pages/useOnScreen.md
@@ -4,6 +4,10 @@ title: useOnScreen
 date: "2018-11-08"
 gist: https://gist.github.com/gragland/d1175eb983772b077cb17ae0841c5329
 sandbox: https://codesandbox.io/s/y7kr0vll4v
+links:
+  - url: https://github.com/thebuilder/react-intersection-observer
+    name: react-intersection-observer
+    description: A more robust and configurable implemenation of this hook.
 code:
   "import { useState, useEffect, useRef } from 'react';\r\n\r\n// Usage\r\nfunction
   App() {\r\n  // Ref for the element that we want to detect whether on screen\r\n

--- a/src/pages/useOnScreen.md
+++ b/src/pages/useOnScreen.md
@@ -7,7 +7,7 @@ sandbox: https://codesandbox.io/s/y7kr0vll4v
 links:
   - url: https://github.com/thebuilder/react-intersection-observer
     name: react-intersection-observer
-    description: A more robust and configurable implemenation of this hook.
+    description: A more robust and configurable implementation of this hook.
 code:
   "import { useState, useEffect, useRef } from 'react';\r\n\r\n// Usage\r\nfunction
   App() {\r\n  // Ref for the element that we want to detect whether on screen\r\n


### PR DESCRIPTION
Thanks for the hook example! It was the original inspiration for upgrading [https://github.com/thebuilder/react-intersection-observer](https://github.com/thebuilder/react-intersection-observer) to support hooks. 🙌 

The example is a really nice starting point, but also limited if you were to use it in production. `react-intersection-observer` supports all configuration options for IntersectionObserver, and the hook correctly handles creating new observers if props/ref changes.

I think it would be a nice addition to provide a link for users looking to use an IntersectionObserver.