### PR TITLE
Fixed URL link to first page

### DIFF
--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -11,7 +11,7 @@ class IndexPage extends React.Component {
   render() {
     const { pageContext } = this.props;
     const { group, index, first, last, pageCount } = pageContext;
-    const previousUrl = index - 1 == 1 ? "" : "/page/" + (index - 1).toString();
+    const previousUrl = index - 1 == 1 ? "/" : `/page/${index - 1}`;
     const nextUrl = "/page/" + (index + 1).toString();
     const { search } = this.state;
 
@@ -72,7 +72,7 @@ class IndexPage extends React.Component {
               .map((value, i) => {
                 const pageNum = i + 1;
                 const isCurrent = index === pageNum;
-                const url = pageNum === 1 ? "" : `/page/${pageNum}`;
+                const url = pageNum === 1 ? "/" : `/page/${pageNum}`;
 
                 return (
                   <li key={i}>


### PR DESCRIPTION
Fixed url link to first page.
When you are on the second page, the link to the previous page is incorrect.
gatsby "Link" expect absolute path, otherwise it be a current path

<img width="878" alt="Снимок экрана 2020-07-02 в 0 21 53" src="https://user-images.githubusercontent.com/9379100/86293106-ad2f5580-bbfa-11ea-9289-a65f9a62ec8b.png">
