### PR TITLE
Adds tuple type in order to be able to access storedValue and setValue correctly

### DIFF
--- a/src/pages/useLocalStorage.md
+++ b/src/pages/useLocalStorage.md
@@ -94,7 +94,7 @@ function App() {
 }
 
 // Hook
-function useLocalStorage<T>(key: string, initialValue: T) {
+function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(() => {


### PR DESCRIPTION
In the `useLocalStorage` hook Typescript example, an explicit type is required for the function in order to be able to use the tuple correctly: `[T, (value: T | ((val: T) => T)) => void]`.

Without this, the type for both `storedValue` and `setValue` is `string | ((value: string | ((val: string) => string)) => void)` which prevents using them properly.

If it looks a little ugly inline I can change it for a declared `type`. :+1: 

