### PR TITLE
Return values as const to make the compiler happy in typescript

### DIFF
--- a/src/pages/useLocalStorage.md
+++ b/src/pages/useLocalStorage.md
@@ -127,6 +127,6 @@ function useLocalStorage<T>(key: string, initialValue: T) {
     }
   };
 
-  return [storedValue, setValue];
+  return [storedValue, setValue] as const;
 }
 ```


### PR DESCRIPTION
Based on this thread:
https://github.com/microsoft/TypeScript/issues/35423
I had to change the return type to be const to satisfy the typescript compiler