### PR TITLE
Set isSearching back to false when no results

### DIFF
--- a/src/pages/useDebounce.md
+++ b/src/pages/useDebounce.md
@@ -37,6 +37,7 @@ function App() {
         });
       } else {
         setResults([]);
+        setIsSearching(false);
       }
     },
     [debouncedSearchTerm] // Only call effect if debounced search term changes


### PR DESCRIPTION
Hey! I just noticed in the example, when there is no `debouncedSearchTerm` `isSearching` should be changed back to `false` so, in case you're using a loading element, it will be hidden if you clear the search.

Hope it helps!