### PR TITLE
Remove `any` from usePrevious

### DIFF
--- a/src/pages/usePrevious.md
+++ b/src/pages/usePrevious.md
@@ -70,10 +70,10 @@ function App() {
 }
 
 // Hook
-function usePrevious<T>(value: T): T {
+function usePrevious<T>(value: T): T | undefined {
   // The ref object is a generic container whose current property is mutable ...
   // ... and can hold any value, similar to an instance property on a class
-  const ref: any = useRef<T>();
+  const ref = useRef<T>();
 
   // Store current value in ref
   useEffect(() => {


### PR DESCRIPTION
It's not uncommon to have a `no-any` eslint rule, and here it's unnecessary.