### PR TITLE
feat(useToggle): no inferrable TS types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the repository for [usehooks.com](https://usehooks.com), a [Gatsby](https://www.gatsbyjs.org) powered blog that publishes easy to understand React Hook code recipes.
 
-If you'd like to submit new post ideas, improve existing posts, or change anything about the website feel free to submit an issue or pull-request. 
+If you'd like to submit new post ideas, improve existing posts, or change anything about the website feel free to submit an issue or pull-request.
 
 Please consider sponsoring this project through my [Github sponsors page](https://github.com/sponsors/gragland). Any level of support is appreciated. I have a few higher tiers that include having your company listed on the usehooks website and newsletter.
 
@@ -34,7 +34,8 @@ To run locally, `yarn`, then `yarn dev`, then open [localhost:8000](https://loca
 [useAnimation](https://usehooks.com/useAnimation/)<br/>
 [useWindowSize](https://usehooks.com/useWindowSize/)<br/>
 [useHover](https://usehooks.com/useHover/)<br/>
-[useLocalStorage](https://usehooks.com/useLocalStorage/)
+[useLocalStorage](https://usehooks.com/useLocalStorage/)<br/>
+[useToggle](https://usehooks.com/useToggle/)
 
 <p align="center">
   <a href="./LICENSE"><strong>Unlicense</strong></a> &mdash; public domain

--- a/src/pages/useToggle.md
+++ b/src/pages/useToggle.md
@@ -19,7 +19,7 @@ import { useCallback, useState } from 'react';
 function App() {
     // Call the hook which returns, current value and the toggler function
     const [isTextChanged, setIsTextChanged] = useToggle();
-    
+
     return (
         <button onClick={setIsTextChanged}>{isTextChanged ? 'Toggled' : 'Click to Toggle'}</button>
     );
@@ -30,11 +30,11 @@ function App() {
 const useToggle = (initialState = false) => {
     // Initialize the state
     const [state, setState] = useState(initialState);
-    
+
     // Define and memorize toggler function in case we pass down the component,
     // This function change the boolean value to it's opposite value
     const toggle = useCallback(() => setState(state => !state), []);
-    
+
     return [state, toggle]
 }
 ```
@@ -55,14 +55,14 @@ function App() {
 
 // Hook
 // Parameter is the boolean, with default "false" value
-const useToggle = (initialState: boolean = false): [boolean, any] => {
+const useToggle = (initialState = false)=> {
     // Initialize the state
     const [state, setState] = useState<boolean>(initialState);
 
     // Define and memorize toggler function in case we pass down the comopnent,
     // This function change the boolean value to it's opposite value
-    const toggle = useCallback((): void => setState(state => !state), []);
+    const toggle = useCallback(() => setState(state => !state), []);
 
-    return [state, toggle]
+    return [state, toggle] as const;
 }
 ```

--- a/src/pages/useToggle.md
+++ b/src/pages/useToggle.md
@@ -55,7 +55,7 @@ function App() {
 
 // Hook
 // Parameter is the boolean, with default "false" value
-const useToggle = (initialState = false)=> {
+const useToggle = (initialState = false) => {
     // Initialize the state
     const [state, setState] = useState<boolean>(initialState);
 


### PR DESCRIPTION
1.  TS can infer the type for function parameter with a default value, see [no-inferrable-types](https://palantir.github.io/tslint/rules/no-inferrable-types/)
2. There is no need for explicit type declarations for the return type. Instead, use TS const assertions.
