### PR TITLE
Impliment media query based dark mode for site

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -177,7 +177,7 @@ const Logo = styled(Link)`
 `;
 
 const InfoSection = styled("section").attrs({ className: "section" })`
-  background-color: #e9fffc;
+  background-color: var(--info-section-background);
 `;
 
 const Container = styled("div").attrs({ className: "container" })`

--- a/src/components/PostTemplate.js
+++ b/src/components/PostTemplate.js
@@ -81,6 +81,7 @@ const PostTemplate = ({ content, frontmatter, slug, permalink }) => {
                 </a>{" "}
                 -{" "}
                 <span
+                  className="links-text"
                   dangerouslySetInnerHTML={{
                     __html: link.description,
                   }}

--- a/src/components/global.css
+++ b/src/components/global.css
@@ -1,3 +1,47 @@
+/* CSS Variables to use with Light & Dark Modes */
+:root {
+  --info-section-background: #e9fffc;
+  --info-font-color: #372f2f;
+  --background: #ffffff;
+  --links-background: #f3f9f8;
+}
+
 code {
   color: inherit !important;
+}
+
+/* Media query for dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --info-font-color: #ffffff;
+    --info-section-background: #073a4c;
+    --background: #000000;
+    --links-background: rgb(40, 31, 31);
+  }
+
+  code {
+    background-color: rgb(40, 37, 37) !important;
+  }
+
+  .subtitle {
+    color: var(--info-font-color) !important;
+  }
+
+  .links-title {
+    color: var(--info-font-color);
+  }
+
+  .links-text {
+    color: var(--info-font-color);
+  }
+}
+
+/* Additional properties that have to be set after query */
+.section {
+  color: var(--info-font-color);
+  background-color: var(--background);
+}
+
+.title {
+  color: var(--info-font-color);
 }

--- a/src/components/styled.js
+++ b/src/components/styled.js
@@ -41,7 +41,7 @@ export const Content = styled.div`
 `;
 
 export const Links = styled.div`
-  background-color: #f3f9f8;
+  background-color: var(--links-background);
   padding: 25px;
   margin-top: 15px;
   border-radius: 10px;


### PR DESCRIPTION
This PR contains the basics changes needed for issue #102 

I did _ask_ in #102 if you wanted me to include an icon for switching back and forth, but I never heard back on that.
So I just went ahead and use some CSS variables and `prefers-color-scheme` media queries to handle it. 

Let me know if you want to change anything, but I think it looks pretty good 😎 
Definitely easier on the 👀 

![firefox_CdPWghqf1c](https://user-images.githubusercontent.com/26460352/198897614-0a5d879f-5d4e-4efa-88ce-01e3161f614d.png)
