### PR TITLE
Mobile reference tables

### DIFF
--- a/usehooks.com/src/content/hooks/useBattery.mdx
+++ b/usehooks.com/src/content/hooks/useBattery.mdx
@@ -25,9 +25,9 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
 <div class="reference">
   ### Return Values
-
   The hook returns an object containing the following properties:
 
+  <div class="table-container">
   | Name             | Type    | Description |
   | ---------------- | ------- | ----------- |
   | supported        | boolean | Indicates whether the Battery Status API is supported in the user's browser. |
@@ -36,6 +36,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | charging         | boolean | Represents whether the system's battery is charging. `true` means the battery is charging, `false` means it's not. |
   | chargingTime     | number  | Represents the time remaining in seconds until the system's battery is fully charged. |
   | dischargingTime  | number  | Represents the time remaining in seconds until the system's battery is completely discharged and the system is about to be suspended. |
+  </div>
 </div>
 
 

--- a/usehooks.com/src/content/hooks/useClickAway.mdx
+++ b/usehooks.com/src/content/hooks/useClickAway.mdx
@@ -38,7 +38,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type         | Description |
   | ---- | ------------ | ----------- |
-  | ref  | React Ref    | This is a ref object returned by the hook. It should be attached to a React element to monitor click events. The ref provides a way to access the properties of the element it is attached to. |
+  | ref  | React ref    | This is a ref object returned by the hook. It should be attached to a React element to monitor click events. The ref provides a way to access the properties of the element it is attached to. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useClickAway.mdx
+++ b/usehooks.com/src/content/hooks/useClickAway.mdx
@@ -27,15 +27,19 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type     | Description |
   | ---- | -------- | ----------- |
   | callback | function | The callback function that is provided as an argument to `useClickAway`. This function is invoked whenever a click event is detected outside of the referenced element. The event object from the click is passed to this callback function. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name | Type         | Description |
   | ---- | ------------ | ----------- |
   | ref  | React Ref    | This is a ref object returned by the hook. It should be attached to a React element to monitor click events. The ref provides a way to access the properties of the element it is attached to. |
+  </div>
 </div>
 
 

--- a/usehooks.com/src/content/hooks/useContinuousRetry.mdx
+++ b/usehooks.com/src/content/hooks/useContinuousRetry.mdx
@@ -26,16 +26,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name     | Type     | Description                                                                                                            |
   | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
   | callback | Function | The callback function to be executed repeatedly until it returns a truthy value.                                       |
   | interval | Number   | (Optional) The interval in milliseconds at which the callback function is executed. Default value is 100 milliseconds. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Type    | Description                                                                                |
   | ------- | ------------------------------------------------------------------------------------------ |
   | Boolean | `true` if the callback function has resolved (returned a truthy value), `false` otherwise. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useContinuousRetry.mdx
+++ b/usehooks.com/src/content/hooks/useContinuousRetry.mdx
@@ -29,8 +29,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name     | Type     | Description                                                                                                            |
   | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-  | callback | Function | The callback function to be executed repeatedly until it returns a truthy value.                                       |
-  | interval | Number   | (Optional) The interval in milliseconds at which the callback function is executed. Default value is 100 milliseconds. |
+  | callback | function | The callback function to be executed repeatedly until it returns a truthy value.                                       |
+  | interval | number   | (Optional) The interval in milliseconds at which the callback function is executed. Default value is 100 milliseconds. |
   </div>
 
   ### Return Value
@@ -38,7 +38,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Type    | Description                                                                                |
   | ------- | ------------------------------------------------------------------------------------------ |
-  | Boolean | `true` if the callback function has resolved (returned a truthy value), `false` otherwise. |
+  | boolean | `true` if the callback function has resolved (returned a truthy value), `false` otherwise. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useCopyToClipboard.mdx
+++ b/usehooks.com/src/content/hooks/useCopyToClipboard.mdx
@@ -33,9 +33,9 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   ### Return Value
 
-  <div class="table-container">
   The `useCopyToClipboard` hook returns an array with the following elements:
 
+  <div class="table-container">
   | Index | Type     | Description                                            |
   | ----- | -------- | ------------------------------------------------------ |
   | 0     | string   | The value that was last copied to the clipboard.       |

--- a/usehooks.com/src/content/hooks/useCopyToClipboard.mdx
+++ b/usehooks.com/src/content/hooks/useCopyToClipboard.mdx
@@ -25,18 +25,22 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name  | Type   | Description                              |
   | ----- | ------ | ---------------------------------------- |
   | value | string | The value to be copied to the clipboard. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   The `useCopyToClipboard` hook returns an array with the following elements:
 
   | Index | Type     | Description                                            |
   | ----- | -------- | ------------------------------------------------------ |
   | 0     | string   | The value that was last copied to the clipboard.       |
   | 1     | function | A function to copy a specified value to the clipboard. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useCountdown.mdx
+++ b/usehooks.com/src/content/hooks/useCountdown.mdx
@@ -25,16 +25,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name    | Type   | Description                                                                                                                                                                                                                                                                                                         |
   | ------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | endTime | Number | The end time of the countdown in milliseconds since the Unix epoch.                                                                                                                                                                                                                                                 |
   | options | Object | An object containing the following options:<ul><li>`interval`: The interval in milliseconds at which the countdown should tick.</li><li>`onComplete`: A callback function to be called when the countdown reaches zero.</li><li>`onTick`: A callback function to be called on each tick of the countdown.</li></ul> |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name  | Type   | Description                         |
   | ----- | ------ | ----------------------------------- |
   | count | Number | The current count of the countdown. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useCountdown.mdx
+++ b/usehooks.com/src/content/hooks/useCountdown.mdx
@@ -28,8 +28,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name    | Type   | Description                                                                                                                                                                                                                                                                                                         |
   | ------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | endTime | Number | The end time of the countdown in milliseconds since the Unix epoch.                                                                                                                                                                                                                                                 |
-  | options | Object | An object containing the following options:<ul><li>`interval`: The interval in milliseconds at which the countdown should tick.</li><li>`onComplete`: A callback function to be called when the countdown reaches zero.</li><li>`onTick`: A callback function to be called on each tick of the countdown.</li></ul> |
+  | endTime | number | The end time of the countdown in milliseconds since the Unix epoch.                                                                                                                                                                                                                                                 |
+  | options | object | An object containing the following options:<ul><li>`interval`: The interval in milliseconds at which the countdown should tick.</li><li>`onComplete`: A callback function to be called when the countdown reaches zero.</li><li>`onTick`: A callback function to be called on each tick of the countdown.</li></ul> |
   </div>
 
   ### Return Value
@@ -37,7 +37,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name  | Type   | Description                         |
   | ----- | ------ | ----------------------------------- |
-  | count | Number | The current count of the countdown. |
+  | count | number | The current count of the countdown. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useCounter.mdx
+++ b/usehooks.com/src/content/hooks/useCounter.mdx
@@ -26,17 +26,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name          | Type   | Description                                        |
   | ------------- | ------ | -------------------------------------------------- |
   | startingValue | number | The initial value for the counter. Default is `0`. |
   | options       | object | Additional options for the counter.                |
   | options.min   | number | The minimum value allowed for the counter.         |
   | options.max   | number | The maximum value allowed for the counter.         |
+  </div>
 
   ### Return Value
 
   The `useCounter` hook returns an array with two elements:
 
+  <div class="table-container">
   | Name            | Parameters        | Description                                          |
   | --------------- | ----------------- | ---------------------------------------------------- |
   | `[0]`           |                   | The current value of the counter.                    |
@@ -44,6 +47,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | `[1].decrement` |                   | Decrements the counter by 1.                         |
   | `[1].set`       | nextCount: number | Sets the counter to the specified `nextCount` value. |
   | `[1].reset`     |                   | Resets the counter to the initial `startingValue`.   |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useDebounce.mdx
+++ b/usehooks.com/src/content/hooks/useDebounce.mdx
@@ -25,16 +25,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name  | Type   | Description |
   | ----- | ------ | ----------- |
   | value | any    | The value that you want to debounce. This can be of any type. |
   | delay | number | The delay time in milliseconds. After this amount of time, the latest value is used. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name          | Type | Description |
   | ------------- | ---- | ----------- |
   | debouncedValue| any  | The debounced value. After the delay time has passed without the `value` changing, this will be updated to the latest `value`. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useDefault.mdx
+++ b/usehooks.com/src/content/hooks/useDefault.mdx
@@ -25,17 +25,21 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name         | Type     | Description |
   | ------------ | -------- | ----------- |
   | initialValue | any      | This is the initial state value provided when calling `useDefault`. |
   | defaultValue | any      | The default value to be used if the state is `undefined` or `null`. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name     | Type            | Description |
   | -------- | --------------- | ----------- |
   | state    | any             | The current state. If the state is `undefined` or `null`, `defaultValue` is returned instead. |
   | setState | function        | The state setter function returned from `React.useState()`. This can be called to update the state. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useDocumentTitle.mdx
+++ b/usehooks.com/src/content/hooks/useDocumentTitle.mdx
@@ -23,9 +23,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name  | Type   | Description                           |
   | ----- | ------ | ------------------------------------- |
   | title | string | The title to be set for the document. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useEventListener.mdx
+++ b/usehooks.com/src/content/hooks/useEventListener.mdx
@@ -28,13 +28,13 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name            | Type               | Description                                                                                                         |
   | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-  | target          | Ref or DOM element | The target element to attach the event listener to. It can be either a ref object (`ref.current`) or a DOM element. |
-  | eventName       | String             | The name of the event to listen for.                                                                                |
-  | handler         | Function           | The event handler function to be executed when the event is triggered.                                              |
-  | options         | Object             | (Optional) Additional options for the event listener.                                                               |
-  | options.capture | Boolean            | Specifies whether the event should be captured during the capturing phase. Default is `false`.                      |
-  | options.passive | Boolean            | Specifies whether the event listener will not call `preventDefault()`. Default is `false`.                          |
-  | options.once    | Boolean            | Specifies whether the event listener should only be invoked once. Default is `false`.                               |
+  | target          | ref or DOM element | The target element to attach the event listener to. It can be either a ref object (`ref.current`) or a DOM element. |
+  | eventName       | string             | The name of the event to listen for.                                                                                |
+  | handler         | function           | The event handler function to be executed when the event is triggered.                                              |
+  | options         | object             | (Optional) Additional options for the event listener.                                                               |
+  | options.capture | boolean            | Specifies whether the event should be captured during the capturing phase. Default is `false`.                      |
+  | options.passive | boolean            | Specifies whether the event listener will not call `preventDefault()`. Default is `false`.                          |
+  | options.once    | boolean            | Specifies whether the event listener should only be invoked once. Default is `false`.                               |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useEventListener.mdx
+++ b/usehooks.com/src/content/hooks/useEventListener.mdx
@@ -25,6 +25,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name            | Type               | Description                                                                                                         |
   | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
   | target          | Ref or DOM element | The target element to attach the event listener to. It can be either a ref object (`ref.current`) or a DOM element. |
@@ -34,6 +35,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | options.capture | Boolean            | Specifies whether the event should be captured during the capturing phase. Default is `false`.                      |
   | options.passive | Boolean            | Specifies whether the event listener will not call `preventDefault()`. Default is `false`.                          |
   | options.once    | Boolean            | Specifies whether the event listener should only be invoked once. Default is `false`.                               |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useFavicon.mdx
+++ b/usehooks.com/src/content/hooks/useFavicon.mdx
@@ -19,9 +19,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type   | Description                                        |
   | ---- | ------ | -------------------------------------------------- |
   | url  | string | The URL of the favicon to be set for the document. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useFetch.mdx
+++ b/usehooks.com/src/content/hooks/useFetch.mdx
@@ -30,8 +30,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name    | Type   | Description                                                                              |
   | ------- | ------ | ---------------------------------------------------------------------------------------- |
-  | url     | String | The URL to fetch data from.                                                              |
-  | options | Object | (Optional) Additional options for the fetch request, such as headers or request methods. |
+  | url     | string | The URL to fetch data from.                                                              |
+  | options | object | (Optional) Additional options for the fetch request, such as headers or request methods. |
   </div>
 
   ### Return Values
@@ -39,9 +39,9 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name        | Type               | Description                                                                    |
   | ----------- | ------------------ | ------------------------------------------------------------------------------ |
-  | state       | Object             | The state object containing the fetched data and error status.                 |
-  | state.error | Error \| undefined | The error object if an error occurred during the fetch, otherwise `undefined`. |
-  | state.data  | Any \| undefined   | The fetched data if the fetch was successful, otherwise `undefined`.           |
+  | state       | object             | The state object containing the fetched data and error status.                 |
+  | state.error | error \| undefined | The error object if an error occurred during the fetch, otherwise `undefined`. |
+  | state.data  | any \| undefined   | The fetched data if the fetch was successful, otherwise `undefined`.           |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useFetch.mdx
+++ b/usehooks.com/src/content/hooks/useFetch.mdx
@@ -27,18 +27,22 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name    | Type   | Description                                                                              |
   | ------- | ------ | ---------------------------------------------------------------------------------------- |
   | url     | String | The URL to fetch data from.                                                              |
   | options | Object | (Optional) Additional options for the fetch request, such as headers or request methods. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name        | Type               | Description                                                                    |
   | ----------- | ------------------ | ------------------------------------------------------------------------------ |
   | state       | Object             | The state object containing the fetched data and error status.                 |
   | state.error | Error \| undefined | The error object if an error occurred during the fetch, otherwise `undefined`. |
   | state.data  | Any \| undefined   | The fetched data if the fetch was successful, otherwise `undefined`.           |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useGeolocation.mdx
+++ b/usehooks.com/src/content/hooks/useGeolocation.mdx
@@ -23,14 +23,17 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name    | Type   | Description |
   | ------- | ------ | ----------- |
   | options | object | This is an optional configuration object provided when calling `useGeolocation`. It is used when calling `navigator.geolocation.getCurrentPosition()` and `navigator.geolocation.watchPosition()`. Some of the attributes it accepts are `enableHighAccuracy`, `timeout`, and `maximumAge`. |
+  </div>
 
   ### Return Values
 
   The hook returns an object containing the following properties:
 
+  <div class="table-container">
   | Name              | Type    | Description |
   | ----------------- | ------- | ----------- |
   | loading           | boolean | A boolean indicating if the geolocation data is currently being fetched. |
@@ -43,6 +46,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | speed             | number  | The current ground speed of the device, specified in meters per second. |
   | timestamp         | number  | The timestamp at which the geolocation data was retrieved. |
   | error             | object  | An error object, if an error occurred while retrieving the geolocation data. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useHistoryState.mdx
+++ b/usehooks.com/src/content/hooks/useHistoryState.mdx
@@ -23,14 +23,17 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name           | Type   | Description                                        |
   | -------------- | ------ | -------------------------------------------------- |
   | initialPresent | object | (Optional) The initial state value. Default: `{}`. |
+  </div>
 
   ### Return Value
 
   The `useHistoryState` hook returns an object with the following properties and functions:
 
+  <div class="table-container">
   | Name    | Type     | Description                                                |
   | ------- | -------- | ---------------------------------------------------------- |
   | state   | any      | The current state value.                                   |
@@ -40,6 +43,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | clear   | function | A function to clear the state history and reset the state. |
   | canUndo | boolean  | Indicates whether an undo action is available.             |
   | canRedo | boolean  | Indicates whether a redo action is available.              |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useHover.mdx
+++ b/usehooks.com/src/content/hooks/useHover.mdx
@@ -27,8 +27,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Index | Type    | Description                                                                |
   | ----- | ------- | -------------------------------------------------------------------------- |
-  | 0     | Ref     | A ref object that can be attached to the element intended to be hovered.   |
-  | 1     | Boolean | A boolean value indicating whether the element is currently being hovered. |
+  | 0     | ref     | A ref object that can be attached to the element intended to be hovered.   |
+  | 1     | boolean | A boolean value indicating whether the element is currently being hovered. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useHover.mdx
+++ b/usehooks.com/src/content/hooks/useHover.mdx
@@ -24,10 +24,12 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   The `useHover` hook returns an array with the following elements:
 
+  <div class="table-container">
   | Index | Type    | Description                                                                |
   | ----- | ------- | -------------------------------------------------------------------------- |
   | 0     | Ref     | A ref object that can be attached to the element intended to be hovered.   |
   | 1     | Boolean | A boolean value indicating whether the element is currently being hovered. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useIdle.mdx
+++ b/usehooks.com/src/content/hooks/useIdle.mdx
@@ -24,15 +24,19 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type   | Description |
   | ---- | ------ | ----------- |
   | ms   | number | This is the duration of idle time (in milliseconds) after which the `idle` state will be set to `true`. The default value is `20 * 1000` (20 seconds). |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name | Type    | Description |
   | ---- | ------- | ----------- |
   | idle | boolean | A boolean indicating if the user is idle. It is `true` if the user has been idle for at least `ms` milliseconds. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
+++ b/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
@@ -26,18 +26,22 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name       | Type    | Default | Description                                                                                                                                                                                                                                                |
   | ---------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | threshold  | number  | 1       | Either a single number or an array of numbers between 0 and 1, indicating at what percentage of the target's visibility the observer's callback should be executed.                                                                                        |
   | root       | Element | null    | The Element that is used as the viewport for checking visibility of the target. Defaults to the browser viewport if not specified or if null.                                                                                                              |
   | rootMargin | string  | "0%"    | Margin around the root. Can have values similar to the CSS margin property. The values can be percentages. This set of values serves to grow or shrink each side of the root element's bounding box before computing intersections. Defaults to all zeros. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name  | Type             | Description                                                                                                     |
   | ----- | ---------------- | --------------------------------------------------------------------------------------------------------------- |
   | ref   | React Ref Object | A React reference that can be attached to a DOM element to observe.                                             |
   | entry | object           | An object containing information about the intersection. This object is similar to `IntersectionObserverEntry`. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
+++ b/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
@@ -30,7 +30,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | Name       | Type    | Default | Description                                                                                                                                                                                                                                                |
   | ---------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | threshold  | number  | 1       | Either a single number or an array of numbers between 0 and 1, indicating at what percentage of the target's visibility the observer's callback should be executed.                                                                                        |
-  | root       | Element | null    | The Element that is used as the viewport for checking visibility of the target. Defaults to the browser viewport if not specified or if null.                                                                                                              |
+  | root       | element | null    | The Element that is used as the viewport for checking visibility of the target. Defaults to the browser viewport if not specified or if null.                                                                                                              |
   | rootMargin | string  | "0%"    | Margin around the root. Can have values similar to the CSS margin property. The values can be percentages. This set of values serves to grow or shrink each side of the root element's bounding box before computing intersections. Defaults to all zeros. |
   </div>
 
@@ -39,7 +39,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name  | Type             | Description                                                                                                     |
   | ----- | ---------------- | --------------------------------------------------------------------------------------------------------------- |
-  | ref   | React Ref Object | A React reference that can be attached to a DOM element to observe.                                             |
+  | ref   | React ref object | A React reference that can be attached to a DOM element to observe.                                             |
   | entry | object           | An object containing information about the intersection. This object is similar to `IntersectionObserverEntry`. |
   </div>
 </div>

--- a/usehooks.com/src/content/hooks/useInterval.mdx
+++ b/usehooks.com/src/content/hooks/useInterval.mdx
@@ -27,16 +27,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type     | Description                                                     |
   | ---- | -------- | --------------------------------------------------------------- |
   | cb   | Function | The callback function to be executed at the specified interval. |
   | ms   | Number   | The interval duration in milliseconds.                          |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name          | Type     | Description                                              |
   | ------------- | -------- | -------------------------------------------------------- |
   | clearInterval | Function | A function to clear the interval and stop the execution. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useInterval.mdx
+++ b/usehooks.com/src/content/hooks/useInterval.mdx
@@ -30,8 +30,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type     | Description                                                     |
   | ---- | -------- | --------------------------------------------------------------- |
-  | cb   | Function | The callback function to be executed at the specified interval. |
-  | ms   | Number   | The interval duration in milliseconds.                          |
+  | cb   | function | The callback function to be executed at the specified interval. |
+  | ms   | number   | The interval duration in milliseconds.                          |
   </div>
 
   ### Return Value
@@ -39,7 +39,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name          | Type     | Description                                              |
   | ------------- | -------- | -------------------------------------------------------- |
-  | clearInterval | Function | A function to clear the interval and stop the execution. |
+  | clearInterval | function | A function to clear the interval and stop the execution. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useIntervalWhen.mdx
+++ b/usehooks.com/src/content/hooks/useIntervalWhen.mdx
@@ -29,11 +29,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name                     | Type     | Description                                                                                         |
   | ------------------------ | -------- | --------------------------------------------------------------------------------------------------- |
-  | cb                       | Function | The callback function to be executed at the specified interval when the condition is met.           |
-  | options                  | Object   | An object containing the following options.                                                         |
-  | options.ms               | Number   | The interval duration in milliseconds.                                                              |
-  | options.when             | Boolean  | The condition that determines whether the interval should be active (`true`) or paused (`false`).   |
-  | options.startImmediately | Boolean  | (Optional) Whether to start the interval immediately when the condition is met. Default is `false`. |
+  | cb                       | function | The callback function to be executed at the specified interval when the condition is met.           |
+  | options                  | object   | An object containing the following options.                                                         |
+  | options.ms               | number   | The interval duration in milliseconds.                                                              |
+  | options.when             | boolean  | The condition that determines whether the interval should be active (`true`) or paused (`false`).   |
+  | options.startImmediately | boolean  | (Optional) Whether to start the interval immediately when the condition is met. Default is `false`. |
   </div>
 
   ### Return Value
@@ -41,7 +41,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Type     | Description                                               |
   | -------- | --------------------------------------------------------- |
-  | Function | A function to clear the interval and pause the execution. |
+  | function | A function to clear the interval and pause the execution. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useIntervalWhen.mdx
+++ b/usehooks.com/src/content/hooks/useIntervalWhen.mdx
@@ -26,6 +26,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name                     | Type     | Description                                                                                         |
   | ------------------------ | -------- | --------------------------------------------------------------------------------------------------- |
   | cb                       | Function | The callback function to be executed at the specified interval when the condition is met.           |
@@ -33,12 +34,15 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | options.ms               | Number   | The interval duration in milliseconds.                                                              |
   | options.when             | Boolean  | The condition that determines whether the interval should be active (`true`) or paused (`false`).   |
   | options.startImmediately | Boolean  | (Optional) Whether to start the interval immediately when the condition is met. Default is `false`. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Type     | Description                                               |
   | -------- | --------------------------------------------------------- |
   | Function | A function to clear the interval and pause the execution. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useIsClient.mdx
+++ b/usehooks.com/src/content/hooks/useIsClient.mdx
@@ -27,9 +27,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   ### Return Value
 
+  <div class="table-container">
   | Name     | Type    | Description                                                        |
   | -------- | ------- | ------------------------------------------------------------------ |
   | isClient | Boolean | `true` if running in a client-side environment, `false` otherwise. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useIsClient.mdx
+++ b/usehooks.com/src/content/hooks/useIsClient.mdx
@@ -30,7 +30,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name     | Type    | Description                                                        |
   | -------- | ------- | ------------------------------------------------------------------ |
-  | isClient | Boolean | `true` if running in a client-side environment, `false` otherwise. |
+  | isClient | boolean | `true` if running in a client-side environment, `false` otherwise. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useIsFirstRender.mdx
+++ b/usehooks.com/src/content/hooks/useIsFirstRender.mdx
@@ -24,9 +24,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Return Value
 
+  <div class="table-container">
   | Name          | Type    | Description                                      |
   | ------------- | ------- | ------------------------------------------------ |
   | isFirstRender | boolean | `true` for the first render, `false` for others. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useKeyPress.mdx
+++ b/usehooks.com/src/content/hooks/useKeyPress.mdx
@@ -24,6 +24,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name                 | Type                  | Description                                                                                            |
   | -------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |
   | key                  | String                | The key to listen for.                                                                                 |
@@ -32,6 +33,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | options.event        | String                | (Optional) The event type to listen for. Default is `"keydown"`.                                       |
   | options.target       | DOM element or Window | (Optional) The target element or `window` object to attach the event listener to. Default is `window`. |
   | options.eventOptions | Object                | (Optional) Additional options for the event listener.                                                  |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useKeyPress.mdx
+++ b/usehooks.com/src/content/hooks/useKeyPress.mdx
@@ -27,12 +27,12 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name                 | Type                  | Description                                                                                            |
   | -------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |
-  | key                  | String                | The key to listen for.                                                                                 |
-  | cb                   | Function              | The callback function to be executed when the key is pressed.                                          |
-  | options              | Object                | (Optional) Additional options for the key press event.                                                 |
-  | options.event        | String                | (Optional) The event type to listen for. Default is `"keydown"`.                                       |
-  | options.target       | DOM element or Window | (Optional) The target element or `window` object to attach the event listener to. Default is `window`. |
-  | options.eventOptions | Object                | (Optional) Additional options for the event listener.                                                  |
+  | key                  | string                | The key to listen for.                                                                                 |
+  | cb                   | function              | The callback function to be executed when the key is pressed.                                          |
+  | options              | object                | (Optional) Additional options for the key press event.                                                 |
+  | options.event        | string                | (Optional) The event type to listen for. Default is `"keydown"`.                                       |
+  | options.target       | DOM element or window | (Optional) The target element or `window` object to attach the event listener to. Default is `window`. |
+  | options.eventOptions | object                | (Optional) Additional options for the event listener.                                                  |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useList.mdx
+++ b/usehooks.com/src/content/hooks/useList.mdx
@@ -27,7 +27,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name        | Type  | Description                                              |
   | ----------- | ----- | -------------------------------------------------------- |
-  | defaultList | Array | The initial list of elements. Default is an empty array. |
+  | defaultList | array | The initial list of elements. Default is an empty array. |
   </div>
 
   ### Return Value
@@ -38,7 +38,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | Name           | Parameters                  | Description                                                       |
   | -------------- | --------------------------- | ----------------------------------------------------------------- |
   | `[0]`          |                             | The current list of elements.                                     |
-  | `[1].set`      | l: Array                    | Replaces the entire list with a new array `l`.                    |
+  | `[1].set`      | l: array                    | Replaces the entire list with a new array `l`.                    |
   | `[1].push`     | element: any                | Appends the `element` to the end of the list.                     |
   | `[1].removeAt` | index: number               | Removes the element at the specified `index` from the list.       |
   | `[1].insertAt` | index: number, element: any | Inserts the `element` at the specified `index` in the list.       |

--- a/usehooks.com/src/content/hooks/useList.mdx
+++ b/usehooks.com/src/content/hooks/useList.mdx
@@ -24,14 +24,17 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name        | Type  | Description                                              |
   | ----------- | ----- | -------------------------------------------------------- |
   | defaultList | Array | The initial list of elements. Default is an empty array. |
+  </div>
 
   ### Return Value
 
   The `useList` hook returns an array with two elements:
 
+  <div class="table-container">
   | Name           | Parameters                  | Description                                                       |
   | -------------- | --------------------------- | ----------------------------------------------------------------- |
   | `[0]`          |                             | The current list of elements.                                     |
@@ -41,6 +44,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | `[1].insertAt` | index: number, element: any | Inserts the `element` at the specified `index` in the list.       |
   | `[1].updateAt` | index: number, element: any | Replaces the element at the specified `index` with the `element`. |
   | `[1].clear`    |                             | Removes all elements from the list.                               |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useLocalStorage.mdx
+++ b/usehooks.com/src/content/hooks/useLocalStorage.mdx
@@ -28,8 +28,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type | Description |
   |------|------|-------------|
-  | key | String | The key used to access the local storage value. |
-  | initialValue | Any | The initial value to use if there is no item in the local storage with the provided key. |
+  | key | string | The key used to access the local storage value. |
+  | initialValue | any | The initial value to use if there is no item in the local storage with the provided key. |
   </div>
 
   ### Return Values
@@ -37,8 +37,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type | Description |
   |------|------|-------------|
-  | localState | Any | The current state of the value stored in local storage. |
-  | handleSetState | Function | A function to set the state of the value in the local storage. This function accepts a new value or a function that returns a new value. The value is also saved in the local storage under the provided key. |
+  | localState | any | The current state of the value stored in local storage. |
+  | handleSetState | function | A function to set the state of the value in the local storage. This function accepts a new value or a function that returns a new value. The value is also saved in the local storage under the provided key. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useLocalStorage.mdx
+++ b/usehooks.com/src/content/hooks/useLocalStorage.mdx
@@ -25,17 +25,21 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type | Description |
   |------|------|-------------|
   | key | String | The key used to access the local storage value. |
   | initialValue | Any | The initial value to use if there is no item in the local storage with the provided key. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name | Type | Description |
   |------|------|-------------|
   | localState | Any | The current state of the value stored in local storage. |
   | handleSetState | Function | A function to set the state of the value in the local storage. This function accepts a new value or a function that returns a new value. The value is also saved in the local storage under the provided key. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useLogger.mdx
+++ b/usehooks.com/src/content/hooks/useLogger.mdx
@@ -25,10 +25,12 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name    | Type   | Description                            |
   | ------- | ------ | -------------------------------------- |
   | name    | string | The name or identifier for the logger. |
   | ...rest | any    | Additional arguments to be logged.     |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useLongPress.mdx
+++ b/usehooks.com/src/content/hooks/useLongPress.mdx
@@ -24,6 +24,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name                 | Type     | Description |
   | -------------------- | -------- | ----------- |
   | callback             | function | This is the function to be executed when a long press event is detected. |
@@ -32,9 +33,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | options.onStart      | function | This function is called when the user starts pressing. |
   | options.onFinish     | function | This function is called when a long press event finishes successfully (the user releases after the threshold). |
   | options.onCancel     | function | This function is called when a press event is cancelled (the user releases before the threshold). |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name         | Type     | Description |
   | ------------ | -------- | ----------- |
   | onMouseDown  | function | This is the mouse down event handler. |
@@ -42,6 +45,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | onMouseLeave | function | This is the mouse leave event handler. |
   | onTouchStart | function | This is the touch start event handler. |
   | onTouchEnd   | function | This is the touch end event handler. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useMap.mdx
+++ b/usehooks.com/src/content/hooks/useMap.mdx
@@ -24,9 +24,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Return Value
 
+  <div class="table-container">
   | Name | Type       | Description                                            |
   | ---- | ---------- | ------------------------------------------------------ |
   | map  | Map object | An instance of the `Map` object with enhanced methods. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useMap.mdx
+++ b/usehooks.com/src/content/hooks/useMap.mdx
@@ -27,7 +27,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type       | Description                                            |
   | ---- | ---------- | ------------------------------------------------------ |
-  | map  | Map object | An instance of the `Map` object with enhanced methods. |
+  | map  | map object | An instance of the `Map` object with enhanced methods. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useMeasure.mdx
+++ b/usehooks.com/src/content/hooks/useMeasure.mdx
@@ -24,17 +24,21 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Return Value
 
+  <div class="table-container">
   | Name | Type | Description |
   | --- | --- | --- |
   | ref | React Ref Object | A React reference that can be attached to a DOM element to observe. |
   | rect | object | An object containing the width and height of the observed element. |
+  </div>
 
   ### rect Object Properties
 
+  <div class="table-container">
   | Property | Type | Description |
   | --- | --- | --- |
   | width | number | Width of the observed element. |
   | height | number | Height of the observed element. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useMeasure.mdx
+++ b/usehooks.com/src/content/hooks/useMeasure.mdx
@@ -27,7 +27,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type | Description |
   | --- | --- | --- |
-  | ref | React Ref Object | A React reference that can be attached to a DOM element to observe. |
+  | ref | React ref object | A React reference that can be attached to a DOM element to observe. |
   | rect | object | An object containing the width and height of the observed element. |
   </div>
 

--- a/usehooks.com/src/content/hooks/useMediaQuery.mdx
+++ b/usehooks.com/src/content/hooks/useMediaQuery.mdx
@@ -25,15 +25,19 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name  | Type   | Description                       |
   | ----- | ------ | --------------------------------- |
   | query | string | The media query to listen changes |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Type    | Description                                                                                         |
   | ------- | --------------------------------------------------------------------------------------------------- |
   | boolean | Returns a boolean value indicating whether the media query matches the current state of the device. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useMouse.mdx
+++ b/usehooks.com/src/content/hooks/useMouse.mdx
@@ -31,13 +31,16 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   The `useMouse` hook returns an array with two elements:
 
+  <div class="table-container">
   | Name    | Type   | Description                                                                      |
   | ------- | ------ | -------------------------------------------------------------------------------- |
   | `state` | object | An object representing the current mouse position and element information.       |
   | `ref`   | object | A ref object that can be used to track the mouse position on a specific element. |
+  </div>
 
   The `state` object has the following properties:
 
+  <div class="table-container">
   | Name                     | Type   | Description                                                                             |
   | ------------------------ | ------ | --------------------------------------------------------------------------------------- |
   | `state.x`                | number | The current horizontal position of the mouse relative to the page.                      |
@@ -46,6 +49,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | `state.elementY`         | number | The current vertical position of the mouse relative to the element's top-left corner.   |
   | `state.elementPositionX` | number | The current horizontal position of the element relative to the page.                    |
   | `state.elementPositionY` | number | The current vertical position of the element relative to the page.                      |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useNetworkState.mdx
+++ b/usehooks.com/src/content/hooks/useNetworkState.mdx
@@ -27,6 +27,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   The `useNetworkState` hook returns an object representing the current network state with the following properties:
 
+  <div class="table-container">
   | Name          | Type    | Description                                                                                                                                                                                          |
   | ------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | online        | boolean | Indicates whether the browser is online or offline.                                                                                                                                                  |
@@ -36,6 +37,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | rtt           | number  | The estimated round-trip latency of the connection, in milliseconds.                                                                                                                                 |
   | saveData      | boolean | Whether the user has requested a reduced data usage mode from the user agent.                                                                                                                        |
   | type          | string  | The type of connection a device is using to communicate with the network. It could be one of the following values: 'bluetooth', 'cellular', 'ethernet', 'none', 'wifi', 'wimax', 'other', 'unknown'. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useObjectState.mdx
+++ b/usehooks.com/src/content/hooks/useObjectState.mdx
@@ -25,18 +25,22 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name         | Type   | Description                         |
   | ------------ | ------ | ----------------------------------- |
   | initialValue | object | (Optional) The initial state value. |
+  </div>
 
   ### Return Value
 
   The `useObjectState` hook returns an array with the following elements:
 
+  <div class="table-container">
   | Index | Type     | Description                            |
   | ----- | -------- | -------------------------------------- |
   | 0     | object   | The current state object.              |
   | 1     | function | A function to update the state object. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useOrientation.mdx
+++ b/usehooks.com/src/content/hooks/useOrientation.mdx
@@ -30,10 +30,12 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   ### Return Value
 
+  <div class="table-container">
   | Name  | Type   | Description                                                                                                                                                                                 |
   | ----- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | angle | number | The current orientation angle of the device in degrees.                                                                                                                                     |
   | type  | string | The current orientation type of the device (e.g., 'portrait-primary', 'landscape-primary', 'portrait-secondary', 'landscape-secondary'). If the type cannot be determined, it is 'UNKNOWN'. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/usePageLeave.mdx
+++ b/usehooks.com/src/content/hooks/usePageLeave.mdx
@@ -27,9 +27,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type     | Description                          |
   | ---- | -------- | ------------------------------------ |
   | cb   | function | The callback function to be invoked. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/usePreferredLanguage.mdx
+++ b/usehooks.com/src/content/hooks/usePreferredLanguage.mdx
@@ -22,9 +22,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Return Value
 
+  <div class="table-container">
   | Name          | Type   | Description                                                                                                   |
   | ------------- | ------ | ------------------------------------------------------------------------------------------------------------- |
   | preferredLang | string | The hook returns a string that represents the preferred language of the user, as set in the browser settings. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/usePrevious.mdx
+++ b/usehooks.com/src/content/hooks/usePrevious.mdx
@@ -22,15 +22,19 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name     | Type | Description                                        |
   | -------- | ---- | -------------------------------------------------- |
   | newValue | any  | The new value to track and return the previous of. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name          | Type | Description                                    |
   | ------------- | ---- | ---------------------------------------------- |
   | previousValue | any  | The previous value of the provided `newValue`. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useQueue.mdx
+++ b/usehooks.com/src/content/hooks/useQueue.mdx
@@ -28,7 +28,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name         | Type  | Description                                                            |
   | ------------ | ----- | ---------------------------------------------------------------------- |
-  | initialValue | Array | (Optional) The initial value for the queue. Default is an empty array. |
+  | initialValue | array | (Optional) The initial value for the queue. Default is an empty array. |
   </div>
 
   ### Return Value
@@ -38,13 +38,13 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name   | Type     | Description                                           |
   | ------ | -------- | ----------------------------------------------------- |
-  | add    | Function | Adds an element to the end of the queue.              |
-  | remove | Function | Removes and returns the first element from the queue. |
-  | clear  | Function | Clears the queue, removing all elements.              |
-  | first  | Any      | The first element in the queue.                       |
-  | last   | Any      | The last element in the queue.                        |
-  | size   | Number   | The number of elements in the queue.                  |
-  | queue  | Array    | The current array representing the queue.             |
+  | add    | function | Adds an element to the end of the queue.              |
+  | remove | function | Removes and returns the first element from the queue. |
+  | clear  | function | Clears the queue, removing all elements.              |
+  | first  | any      | The first element in the queue.                       |
+  | last   | any      | The last element in the queue.                        |
+  | size   | number   | The number of elements in the queue.                  |
+  | queue  | array    | The current array representing the queue.             |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useQueue.mdx
+++ b/usehooks.com/src/content/hooks/useQueue.mdx
@@ -25,14 +25,17 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name         | Type  | Description                                                            |
   | ------------ | ----- | ---------------------------------------------------------------------- |
   | initialValue | Array | (Optional) The initial value for the queue. Default is an empty array. |
+  </div>
 
   ### Return Value
 
   The `useQueue` hook returns an object with the following properties and methods:
 
+  <div class="table-container">
   | Name   | Type     | Description                                           |
   | ------ | -------- | ----------------------------------------------------- |
   | add    | Function | Adds an element to the end of the queue.              |
@@ -42,6 +45,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | last   | Any      | The last element in the queue.                        |
   | size   | Number   | The number of elements in the queue.                  |
   | queue  | Array    | The current array representing the queue.             |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useRandomInterval.mdx
+++ b/usehooks.com/src/content/hooks/useRandomInterval.mdx
@@ -27,18 +27,22 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name             | Type     | Description                                                         |
   | ---------------- | -------- | ------------------------------------------------------------------- |
   | cb               | Function | The callback function to be executed at random intervals.           |
   | options          | Object   | An object containing the following options.                         |
   | options.minDelay | Number   | The minimum delay in milliseconds between each callback invocation. |
   | options.maxDelay | Number   | The maximum delay in milliseconds between each callback invocation. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Type     | Description                                                             |
   | -------- | ----------------------------------------------------------------------- |
   | Function | A function to clear the timeout and stop the random interval execution. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useRandomInterval.mdx
+++ b/usehooks.com/src/content/hooks/useRandomInterval.mdx
@@ -30,10 +30,10 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name             | Type     | Description                                                         |
   | ---------------- | -------- | ------------------------------------------------------------------- |
-  | cb               | Function | The callback function to be executed at random intervals.           |
-  | options          | Object   | An object containing the following options.                         |
-  | options.minDelay | Number   | The minimum delay in milliseconds between each callback invocation. |
-  | options.maxDelay | Number   | The maximum delay in milliseconds between each callback invocation. |
+  | cb               | function | The callback function to be executed at random intervals.           |
+  | options          | object   | An object containing the following options.                         |
+  | options.minDelay | number   | The minimum delay in milliseconds between each callback invocation. |
+  | options.maxDelay | number   | The maximum delay in milliseconds between each callback invocation. |
   </div>
 
   ### Return Value
@@ -41,7 +41,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Type     | Description                                                             |
   | -------- | ----------------------------------------------------------------------- |
-  | Function | A function to clear the timeout and stop the random interval execution. |
+  | function | A function to clear the timeout and stop the random interval execution. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useRenderCount.mdx
+++ b/usehooks.com/src/content/hooks/useRenderCount.mdx
@@ -27,7 +27,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name        | Type   | Description                                     |
   | ----------- | ------ | ----------------------------------------------- |
-  | renderCount | Number | The number of times the component has rendered. |
+  | renderCount | number | The number of times the component has rendered. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useRenderCount.mdx
+++ b/usehooks.com/src/content/hooks/useRenderCount.mdx
@@ -24,10 +24,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
 <div class="reference">
   ### Return Value
-
+  <div class="table-container">
   | Name        | Type   | Description                                     |
   | ----------- | ------ | ----------------------------------------------- |
   | renderCount | Number | The number of times the component has rendered. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useRenderInfo.mdx
+++ b/usehooks.com/src/content/hooks/useRenderInfo.mdx
@@ -27,11 +27,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name                 | Type   | Description                                                       |
   | -------------------- | ------ | ----------------------------------------------------------------- |
-  | info                 | Object | An object containing information about the component's rendering. |
-  | info.name            | String | The name of the component.                                        |
-  | info.renders         | Number | The number of times the component has rendered.                   |
-  | info.sinceLastRender | Number | The time elapsed in milliseconds since the last render.           |
-  | info.timestamp       | Number | The timestamp of the current render.                              |
+  | info                 | object | An object containing information about the component's rendering. |
+  | info.name            | string | The name of the component.                                        |
+  | info.renders         | number | The number of times the component has rendered.                   |
+  | info.sinceLastRender | number | The time elapsed in milliseconds since the last render.           |
+  | info.timestamp       | number | The timestamp of the current render.                              |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useRenderInfo.mdx
+++ b/usehooks.com/src/content/hooks/useRenderInfo.mdx
@@ -24,6 +24,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Return Value
 
+  <div class="table-container">
   | Name                 | Type   | Description                                                       |
   | -------------------- | ------ | ----------------------------------------------------------------- |
   | info                 | Object | An object containing information about the component's rendering. |
@@ -31,6 +32,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | info.renders         | Number | The number of times the component has rendered.                   |
   | info.sinceLastRender | Number | The time elapsed in milliseconds since the last render.           |
   | info.timestamp       | Number | The timestamp of the current render.                              |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useScript.mdx
+++ b/usehooks.com/src/content/hooks/useScript.mdx
@@ -26,16 +26,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name             | Type   | Description |
   | ---------------- | ------ | ----------- |
   | src              | string | This is the URL source of the script to be loaded. |
   | options          | object | This is an optional configuration object provided when calling `useScript`. It currently accepts one property `removeOnUnmount` which when set to `true`, will remove the script tag from the document body on component unmount. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name   | Type   | Description |
   | ------ | ------ | ----------- |
   | status | string | This represents the status of the script load. Possible values are: `idle`, `loading`, `ready`, and `error`. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useSessionStorage.mdx
+++ b/usehooks.com/src/content/hooks/useSessionStorage.mdx
@@ -30,8 +30,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name         | Type   | Description                                                                                |
   | ------------ | ------ | ------------------------------------------------------------------------------------------ |
-  | key          | String | The key used to access the session storage value.                                          |
-  | initialValue | Any    | The initial value to use if there is no item in the session storage with the provided key. |
+  | key          | string | The key used to access the session storage value.                                          |
+  | initialValue | any    | The initial value to use if there is no item in the session storage with the provided key. |
   </div>
 
   ### Return Values
@@ -39,8 +39,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name           | Type     | Description                                                                                                                                                                                                       |
   | -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | localState     | Any      | The current state of the value stored in session storage.                                                                                                                                                         |
-  | handleSetState | Function | A function to set the state of the value in the session storage. This function accepts a new value or a function that returns a new value. The value is also saved in the session storage under the provided key. |
+  | localState     | any      | The current state of the value stored in session storage.                                                                                                                                                         |
+  | handleSetState | function | A function to set the state of the value in the session storage. This function accepts a new value or a function that returns a new value. The value is also saved in the session storage under the provided key. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useSessionStorage.mdx
+++ b/usehooks.com/src/content/hooks/useSessionStorage.mdx
@@ -27,17 +27,21 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name         | Type   | Description                                                                                |
   | ------------ | ------ | ------------------------------------------------------------------------------------------ |
   | key          | String | The key used to access the session storage value.                                          |
   | initialValue | Any    | The initial value to use if there is no item in the session storage with the provided key. |
+  </div>
 
   ### Return Values
 
+  <div class="table-container">
   | Name           | Type     | Description                                                                                                                                                                                                       |
   | -------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | localState     | Any      | The current state of the value stored in session storage.                                                                                                                                                         |
   | handleSetState | Function | A function to set the state of the value in the session storage. This function accepts a new value or a function that returns a new value. The value is also saved in the session storage under the provided key. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useSet.mdx
+++ b/usehooks.com/src/content/hooks/useSet.mdx
@@ -28,7 +28,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name   | Type  | Description                            |
   | ------ | ----- | -------------------------------------- |
-  | values | Array | (Optional) Initial values for the set. |
+  | values | array | (Optional) Initial values for the set. |
   </div>
 
   ### Return Value
@@ -36,7 +36,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type | Description                                            |
   | ---- | ---- | ------------------------------------------------------ |
-  | set  | Set  | An instance of the `Set` object with enhanced methods. |
+  | set  | set  | An instance of the `Set` object with enhanced methods. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useSet.mdx
+++ b/usehooks.com/src/content/hooks/useSet.mdx
@@ -25,15 +25,19 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name   | Type  | Description                            |
   | ------ | ----- | -------------------------------------- |
   | values | Array | (Optional) Initial values for the set. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name | Type | Description                                            |
   | ---- | ---- | ------------------------------------------------------ |
   | set  | Set  | An instance of the `Set` object with enhanced methods. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useThrottle.mdx
+++ b/usehooks.com/src/content/hooks/useThrottle.mdx
@@ -24,16 +24,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name     | Type   | Description                                              |
   | -------- | ------ | -------------------------------------------------------- |
   | value    | any    | The value to throttle.                                   |
   | interval | number | (Optional) The interval in milliseconds. Default: 500ms. |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name           | Type | Description                                                    |
   | -------------- | ---- | -------------------------------------------------------------- |
   | throttledValue | any  | The throttled value that is updated at most once per interval. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useTimeout.mdx
+++ b/usehooks.com/src/content/hooks/useTimeout.mdx
@@ -28,8 +28,8 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name | Type     | Description                                                       |
   | ---- | -------- | ----------------------------------------------------------------- |
-  | cb   | Function | The callback function to be executed after the specified timeout. |
-  | ms   | Number   | The duration of the timeout in milliseconds.                      |
+  | cb   | function | The callback function to be executed after the specified timeout. |
+  | ms   | number   | The duration of the timeout in milliseconds.                      |
   </div>
 
   ### Return Value
@@ -37,7 +37,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name         | Type     | Description                                                               |
   | ------------ | -------- | ------------------------------------------------------------------------- |
-  | clearTimeout | Function | A function to clear the timeout and cancel the execution of the callback. |
+  | clearTimeout | function | A function to clear the timeout and cancel the execution of the callback. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useTimeout.mdx
+++ b/usehooks.com/src/content/hooks/useTimeout.mdx
@@ -25,16 +25,20 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name | Type     | Description                                                       |
   | ---- | -------- | ----------------------------------------------------------------- |
   | cb   | Function | The callback function to be executed after the specified timeout. |
   | ms   | Number   | The duration of the timeout in milliseconds.                      |
+  </div>
 
   ### Return Value
 
+  <div class="table-container">
   | Name         | Type     | Description                                                               |
   | ------------ | -------- | ------------------------------------------------------------------------- |
   | clearTimeout | Function | A function to clear the timeout and cancel the execution of the callback. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useToggle.mdx
+++ b/usehooks.com/src/content/hooks/useToggle.mdx
@@ -22,18 +22,22 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Parameters
 
+  <div class="table-container">
   | Name         | Type    | Description                                       |
   | ------------ | ------- | ------------------------------------------------- |
   | initialValue | boolean | (Optional) The initial value of the toggle state. |
+  </div>
 
   ### Return Value
 
   The `useToggle` hook returns an array with the following elements:
 
+  <div class="table-container">
   | Index | Type     | Description                                   |
   | ----- | -------- | --------------------------------------------- |
   | 0     | boolean  | The current state of the toggle.              |
   | 1     | function | A function to toggle the state of the toggle. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useVisibilityChange.mdx
+++ b/usehooks.com/src/content/hooks/useVisibilityChange.mdx
@@ -29,7 +29,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   <div class="table-container">
   | Name            | Type    | Description                                                     |
   | --------------- | ------- | --------------------------------------------------------------- |
-  | documentVisible | Boolean | `true` if the document is currently visible, `false` otherwise. |
+  | documentVisible | boolean | `true` if the document is currently visible, `false` otherwise. |
   </div>
 </div>
 

--- a/usehooks.com/src/content/hooks/useVisibilityChange.mdx
+++ b/usehooks.com/src/content/hooks/useVisibilityChange.mdx
@@ -26,9 +26,11 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 <div class="reference">
   ### Return Value
 
+  <div class="table-container">
   | Name            | Type    | Description                                                     |
   | --------------- | ------- | --------------------------------------------------------------- |
   | documentVisible | Boolean | `true` if the document is currently visible, `false` otherwise. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useWindowScroll.mdx
+++ b/usehooks.com/src/content/hooks/useWindowScroll.mdx
@@ -29,10 +29,12 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   The `useWindowScroll` hook returns an array with two elements:
 
+  <div class="table-container">
   | Name       | Type     | Description                                                              |
   | ---------- | -------- | ------------------------------------------------------------------------ |
   | `state`    | object   | An object representing the current window scroll position.               |
   | `scrollTo` | function | A function that can be used to scroll the window to a specific position. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/content/hooks/useWindowSize.mdx
+++ b/usehooks.com/src/content/hooks/useWindowSize.mdx
@@ -28,10 +28,12 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
   The `useWindowSize` hook returns an object with the following properties:
 
+  <div class="table-container">
   | Name   | Type   | Description                                  |
   | ------ | ------ | -------------------------------------------- |
   | width  | number | The current width of the window, in pixels.  |
   | height | number | The current height of the window, in pixels. |
+  </div>
 </div>
 
 <CodePreview

--- a/usehooks.com/src/pages/[hook].astro
+++ b/usehooks.com/src/pages/[hook].astro
@@ -196,7 +196,7 @@ const installSnippet = experimental
 
     :global(.reference td:not(:last-of-type)),
     :global(.reference th:not(:last-of-type)) {
-      min-width: 120px;
+      min-width: 10ch;
     }
 
     :global(.reference td:last-of-type),

--- a/usehooks.com/src/pages/[hook].astro
+++ b/usehooks.com/src/pages/[hook].astro
@@ -163,9 +163,13 @@ const installSnippet = experimental
       font-size: clamp(.9rem, 2vw, 1.1rem);
     }
 
-    :global(.reference table) {
+    :global(.reference .table-container) {
       width: 100%;
+      overflow-x: auto;
       border: 0.07rem solid rgba(249, 244, 218, 0.1);
+    }
+
+    :global(.reference table) {
       border-radius: .9rem;
       font-size: clamp(1rem, 2.1vw, 1.2rem);
     }
@@ -175,9 +179,14 @@ const installSnippet = experimental
     }
 
     :global(.reference thead) {
-      border-bottom: 0.07rem solid rgba(249, 244, 218, 0.1);
+      /* border-bottom: 0.07rem solid rgba(249, 244, 218, 0.1); */
+      background-color: rgba(249, 244, 218, 0.1);
       font-size: var(--font-sm);
       text-align: left;
+    }
+
+    :global(.reference tr:not(:last-of-type)) {
+      border-bottom: 0.07rem solid rgba(249, 244, 218, 0.1);
     }
 
     :global(.reference td),
@@ -185,8 +194,15 @@ const installSnippet = experimental
       padding: .5rem .75rem;
     }
 
-    :global(.reference td:not(:last-of-type)) {
-      width: 20%;
+    :global(.reference td:not(:last-of-type)),
+    :global(.reference th:not(:last-of-type)) {
+      min-width: 110px;
+    }
+
+    :global(.reference td:last-of-type),
+    :global(.reference th:last-of-type) {
+      width: 100%;
+      min-width: 300px;
     }
 
     .related-hooks {

--- a/usehooks.com/src/pages/[hook].astro
+++ b/usehooks.com/src/pages/[hook].astro
@@ -191,12 +191,12 @@ const installSnippet = experimental
 
     :global(.reference td),
     :global(.reference th) {
-      padding: .5rem .75rem;
+      padding: .5rem 1.2rem .5rem .75rem;
     }
 
     :global(.reference td:not(:last-of-type)),
     :global(.reference th:not(:last-of-type)) {
-      min-width: 110px;
+      min-width: 120px;
     }
 
     :global(.reference td:last-of-type),


### PR DESCRIPTION
This PR
- styles the reference tables a bit and makes them scroll horizontally for narrower screens
- fixes capitalization for consistency

Here is a preview at a narrow width:
<img width="433" alt="image" src="https://github.com/uidotdev/usehooks/assets/871315/82ac6acd-18f6-4359-bc47-b7b27564a8eb">
