### PR TITLE
fix: Fix useIntersectionObsever rootMargin Default Value

### DIFF
--- a/index.js
+++ b/index.js
@@ -483,7 +483,7 @@ export function useIdle(ms = 1000 * 60) {
 }
 
 export function useIntersectionObserver(options = {}) {
-  const { threshold = 1, root = null, rootMargin = "0%" } = options;
+  const { threshold = 1, root = null, rootMargin = "0px 0px 0px 0px" } = options;
   const ref = React.useRef(null);
   const [entry, setEntry] = React.useState(null);
 

--- a/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
+++ b/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
@@ -60,7 +60,7 @@ const Section = ({ imgUrl, caption, href }) => {
   const [ref, entry] = useIntersectionObserver({
     threshold: 0,
     root: null,
-    rootMargin: "0px",
+    rootMargin: "0px 0px 0px 0px",
   });
 
   return (

--- a/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
+++ b/usehooks.com/src/content/hooks/useIntersectionObserver.mdx
@@ -31,7 +31,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | ---------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
   | threshold  | number  | 1       | Either a single number or an array of numbers between 0 and 1, indicating at what percentage of the target’s visibility the observer’s callback should be executed.                                                                                        |
   | root       | element | null    | The Element that is used as the viewport for checking visibility of the target. Defaults to the browser viewport if not specified or if null.                                                                                                              |
-  | rootMargin | string  | "0%"    | Margin around the root. Can have values similar to the CSS margin property. The values can be percentages. This set of values serves to grow or shrink each side of the root element’s bounding box before computing intersections. Defaults to all zeros. |
+  | rootMargin | string  | "0px 0px 0px 0px"    | Margin around the root. Can have values similar to the CSS margin property. The values can be percentages. This set of values serves to grow or shrink each side of the root element’s bounding box before computing intersections. Defaults to all zeros. |
   </div>
 
   ### Return Value


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin

>If rootMargin isn't specified when the object was instantiated, it defaults to the string "0px 0px 0px 0px", meaning that the intersection will be computed between the root element's unmodified bounds rectangle and the target's bounds. [How intersections are calculated](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#how_intersection_is_calculated) describes how the rootMargin is used in more detail.

In the documentation, it states that the default value for rootMargin is "0px 0px 0px 0px", so I thought it would be nice to modify the default value.

It actually has the value "0px 0px 0px 0px".

However, there are no functional issues with the existing code.
This is just a Pull Request to make useIntersectionObserver more clear. 🙏