### PR TITLE
Fix on useVisiblityChange Hook - set correct visibility when component first mounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1201,6 +1201,7 @@ export function useVisibilityChange() {
         setDocumentVisibility(true);
       }
     };
+    handleChange()
 
     document.addEventListener("visibilitychange", handleChange);
 


### PR DESCRIPTION
Discovered the following unwanted behaviour:

Using this package for a content script in a browser extension. The content script is being mounted in all tabs of a window, even without being focused. This lead to the circumstance, that all tabs thought they are visible (since the default value for is true), because the "visibilitychange" event has to be triggered for all of them to update. This doesn't happen though when they get first mounted.

This simple 1 line addition runs the function to set the actual current state when first being mounted