### PR TITLE
Add Typescript types definition for useKeyPress

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -252,4 +252,14 @@ declare module "@uidotdev/usehooks" {
     width: number | null;
     height: number | null;
   };
+
+  export function useKeyPress(
+    key: string,
+    cb: (e: Event) => void,
+    options: {
+      event?: string;
+      target?: window | HTMLElement;
+      eventOptions?: React.AddEventListenerOptions;
+    }
+  ): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,10 +256,10 @@ declare module "@uidotdev/usehooks" {
   export function useKeyPress(
     key: string,
     cb: (e: Event) => void,
-    options: {
-      event?: string;
-      target?: window | HTMLElement;
-      eventOptions?: React.AddEventListenerOptions;
+    options?: {
+      event?: keyof GlobalEventHandlersEventMap;
+      target?: Window | HTMLElement;
+      eventOptions?: AddEventListenerOptions;
     }
   ): void;
 }


### PR DESCRIPTION
As mentioned in #216, the experimental hooks have missing type definitions. This PR adds types for `useKeyPress`.