### PR TITLE
Added Missing Return Type at the useQueue hook.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,7 @@ export type CustomQueue<T> = {
   first: T | undefined;
   last: T | undefined;
   size: number;
+  queue: T[];
 };
 
 export type RenderInfo = {


### PR DESCRIPTION
Hi, It seems to be added the queue on the return statement of `useQueue` [in: #207], but a types definition still missing.

...but I realized while writing this PR, As well as perhaps you might intend to add a type definition later. https://github.com/uidotdev/usehooks/pull/217#issuecomment-1676463549

Thanks for nice library.