### PR TITLE
Make `useIntersectionObserver` ref type generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,9 +165,9 @@ declare module "@uidotdev/usehooks" {
 
   export function useIdle(ms?: number): boolean;
 
-  export function useIntersectionObserver(
+  export function useIntersectionObserver<T extends Element>(
     options?: IntersectionObserverInit
-  ): [React.MutableRefObject<Element>, IntersectionObserverEntry | null];
+  ): [React.MutableRefObject<T>, IntersectionObserverEntry | null];
 
   export function useIsClient(): boolean;
 


### PR DESCRIPTION
This PR allows the element type to be specified in order to expose non-generic properties and methods:

```
const [ref, entry] = useIntersectionObserver<HTMLVideoElement>()

useEffect(() => {
  if (entry?.isIntersecting) {
    ref.current?.play()
  }
}, [entry?.isIntersecting, ref])
```