### PR TITLE
Export type declaration for `useSessionStorage`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,6 +225,11 @@ declare module "@uidotdev/usehooks" {
     }
   ): "idle" | "loading" | "ready" | "error";
 
+  export function useSessionStorage<T>(
+    key: string,
+    initialValue: T
+  ): [T, React.Dispatch<React.SetStateAction<T>>];
+
   export function useSet<T>(values?: T[]): Set<T>;
 
   export function useSpeech(text: string, options?: SpeechOptions): SpeechState;


### PR DESCRIPTION
This PR adds an export of a type declaration for `useSessionStorage`, similar to the one in https://github.com/uidotdev/usehooks/pull/228.