### PR TITLE
re-write useHover hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -414,29 +414,19 @@ export function useHistoryState(initialPresent = {}) {
 
 export function useHover() {
   const [hovering, setHovering] = React.useState(false);
-  const ref = React.useRef(null);
-
-  React.useEffect(() => {
-    const node = ref.current;
-
-    if (!node) return;
-
+  
+  const ref = React.useCallback((node) => {
     const handleMouseEnter = () => {
       setHovering(true);
     };
-
     const handleMouseLeave = () => {
       setHovering(false);
     };
-
-    node.addEventListener("mouseenter", handleMouseEnter);
-    node.addEventListener("mouseleave", handleMouseLeave);
-
-    return () => {
-      node.removeEventListener("mouseenter", handleMouseEnter);
-      node.removeEventListener("mouseleave", handleMouseLeave);
-    };
-  }, []);
+    if (node) {
+      node.addEventListener("mouseenter", handleMouseEnter);
+      node.addEventListener("mouseleave", handleMouseLeave);
+    }
+  })
 
   return [ref, hovering];
 }


### PR DESCRIPTION
The original solution only works when ref is set on the first render.
However, under some circumstances it might be available only after first render.
In this case, the original solution will break.
There is no cleanup function set because once the node is removed, the event listeners attached to it will also be removed automatically.
What do you think?
Reference article(https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780)