### PR TITLE
feat: add useHandler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,14 +135,14 @@ declare module "@uidotdev/usehooks" {
       max?: number;
     }
   ): [
-    number,
-    {
-      increment: () => void;
-      decrement: () => void;
-      set: (nextCount: number) => void;
-      reset: () => void;
-    }
-  ];
+      number,
+      {
+        increment: () => void;
+        decrement: () => void;
+        set: (nextCount: number) => void;
+        reset: () => void;
+      }
+    ];
 
   export function useDebounce<T>(value: T, delay: number): T;
 
@@ -260,4 +260,6 @@ declare module "@uidotdev/usehooks" {
     width: number | null;
     height: number | null;
   };
+
+  export function useHandler(handler: any): any;
 }

--- a/index.js
+++ b/index.js
@@ -1365,3 +1365,11 @@ export function useWindowSize() {
 
   return size;
 }
+
+export function useHandler(handler) {
+  const handlerRef = useRef(handler);
+
+  handlerRef.current = handler;
+
+  return useRef((...args) => handlerRef.current(...args)).current;
+}


### PR DESCRIPTION
Create an immutable callback reference that can always take the value from the latest props internally. Unlike useCallback, when the dependency value of useCallback changes, its reference will also change, allowing the memo component to re-render, while the reference of useHandler does not Mutability allows memo components to avoid unnecessary rendering.

[codesandbox examples](https://codesandbox.io/s/agitated-newton-565y6y?file=/src/useHandler.tsx)
