### PR TITLE
Accept first change on throttle

### DIFF
--- a/index.js
+++ b/index.js
@@ -1244,7 +1244,7 @@ export function useThrottle(value, interval = 500) {
 
   React.useEffect(() => {
     const now = Date.now();
-    
+
     if (!lastupdated.current || now >= lastUpdated.current + interval) {
       lastUpdated.current = now;
       setThrottledValue(value);

--- a/index.js
+++ b/index.js
@@ -1244,8 +1244,8 @@ export function useThrottle(value, interval = 500) {
 
   React.useEffect(() => {
     const now = Date.now();
-
-    if (lastUpdated.current && now >= lastUpdated.current + interval) {
+    
+    if (!lastupdated.current || now >= lastUpdated.current + interval) {
       lastUpdated.current = now;
       setThrottledValue(value);
     } else {


### PR DESCRIPTION
If sending data too quickly at the start of the hook, it would never accept a first value.