### PR TITLE
Fix useObjectState typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -207,7 +207,7 @@ declare module "@uidotdev/usehooks" {
 
   export function useNetworkState(): NetworkState;
 
-  export function useObjectState<T>(initialValue: T): [T, (arg: T) => void];
+  export function useObjectState<T>(initialValue: T): [T, (arg: Partial<T>) => void];
 
   export function useOrientation(): {
     angle: number;


### PR DESCRIPTION
useObjectState accepts a partial object to update a property state, but the type definition was expecting the whole object to be updated.