### PR TITLE
Update useMap Typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ declare module "@uidotdev/usehooks" {
     options?: LongPressOptions
   ): LongPressFns;
 
-  export function useMap<T>(initialState?: T): Map<T, any>;
+  export function useMap<K, V>(initialState?: Map<K, V>): Map<K, V>;
 
   export function useMeasure<T extends Element>(): [
     React.RefCallback<T>,


### PR DESCRIPTION
This PR updates the type signature of the useMap function to improve type safety as reference in #278 By specifying separate generic types for keys and values (K and V), we ensure that the useMap hook is more accurately typed