### PR TITLE
fix: Restore original document title on unmount in useDocumentTitle hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,8 +263,13 @@ export function useDefault(initialValue, defaultValue) {
 }
 
 export function useDocumentTitle(title) {
+  const initial = React.useRef(document.title);
+
   React.useEffect(() => {
     document.title = title;
+    return () => {
+        document.title = initial.current;
+    }
   }, [title]);
 }
 


### PR DESCRIPTION
This pull request addresses an issue where the useDocumentTitle hook does not revert the document title back to its original value when the component using it unmounts. Without this adjustment, navigating away from a component that sets the document title would leave the title in an incorrect state, potentially confusing users and affecting the user experience negatively.