### PR TITLE
Fix useThrottle timing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1240,19 +1240,20 @@ export function useSet(values) {
 
 export function useThrottle(value, interval = 500) {
   const [throttledValue, setThrottledValue] = React.useState(value);
-  const lastUpdated = React.useRef(null);
+  const lastUpdated = React.useRef(0);
 
   React.useEffect(() => {
     const now = Date.now();
+    const sinceLastUpdate = now - lastUpdated.current;
 
     if (lastUpdated.current && now >= lastUpdated.current + interval) {
       lastUpdated.current = now;
       setThrottledValue(value);
     } else {
       const id = window.setTimeout(() => {
-        lastUpdated.current = now;
+        lastUpdated.current = Date.now();
         setThrottledValue(value);
-      }, interval);
+      }, interval - sinceLastUpdate);
 
       return () => window.clearTimeout(id);
     }


### PR DESCRIPTION
This fixes a couple issues that lead to subtle timing bugs in useThrottle. For an example, see [this codesandbox](https://codesandbox.io/p/sandbox/gracious-pike-vmzh2k?file=%2Fsrc%2FApp.js%3A11%2C69-12%2C39) and notice how throttledValue (current implementation) updates kind of choppily and drops some values, whereas throttledValue2 (includes this fix) works as you'd expect.

First fix is that the `now` variable inside `setTimeout` does not actually refer to the current time, it refers to the time `setTimeout` was called. That means `lastUpdated.current` will be incorrect (too low) for the next update. Instead we should get a new `Date.now()` value.

Second fix is that the `setTimeout` is currently delayed by the full value  of `interval`, even if there is only like a millisecond left until the interval elapses. Fix is to instead delay it by `interval` minus the time since the last update.