### PR TITLE
Add useMemo call to useLocalStorage so that the value returned only changes if store actually changes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,10 +622,14 @@ export function useLocalStorage(key, initialValue) {
     getLocalStorageServerSnapshot
   );
 
+  const currentValue = React.useMemo(() => {
+    return store ? JSON.parse(store) : initialValue;
+  }, [store, initialValue]);
+
   const setState = React.useCallback(
     (v) => {
       try {
-        const nextState = typeof v === "function" ? v(JSON.parse(store)) : v;
+        const nextState = typeof v === "function" ? v(currentValue) : v;
 
         if (nextState === undefined || nextState === null) {
           removeLocalStorageItem(key);
@@ -636,7 +640,7 @@ export function useLocalStorage(key, initialValue) {
         console.warn(e);
       }
     },
-    [key, store]
+    [key, currentValue]
   );
 
   React.useEffect(() => {
@@ -648,7 +652,7 @@ export function useLocalStorage(key, initialValue) {
     }
   }, [key, initialValue]);
 
-  return [store ? JSON.parse(store) : initialValue, setState];
+  return [currentValue, setState];
 }
 
 export function useLockBodyScroll() {


### PR DESCRIPTION
At the moment if a component that uses `useLocalStorage` rerenders then `useLocalStorage` will call `JSON.parse(store)` as a result of the rerender. The value of `store` won't have changed, but the new call to `JSON.parse` will mean that a new value is returned with identical contents to the old value. Any hooks then using that value in their deps array will then have to be run again, even though the actual data is the same.

I've updated useLocalStorage so that it uses `useMemo` to avoid repeated calls to `JSON.parse` with the same store value.