### PR TITLE
Fix useLocalStorage batch updates not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -614,7 +614,7 @@ const getLocalStorageServerSnapshot = () => {
 };
 
 export function useLocalStorage(key, initialValue) {
-  const getSnapshot = () => getLocalStorageItem(key);
+  const getSnapshot = React.useCallback(() => getLocalStorageItem(key), [key]);
 
   const store = React.useSyncExternalStore(
     useLocalStorageSubscribe,
@@ -625,7 +625,7 @@ export function useLocalStorage(key, initialValue) {
   const setState = React.useCallback(
     (v) => {
       try {
-        const nextState = typeof v === "function" ? v(JSON.parse(store)) : v;
+        const nextState = typeof v === "function" ? v(JSON.parse(getSnapshot())) : v;
 
         if (nextState === undefined || nextState === null) {
           removeLocalStorageItem(key);
@@ -636,7 +636,7 @@ export function useLocalStorage(key, initialValue) {
         console.warn(e);
       }
     },
-    [key, store]
+    [key, getSnapshot]
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
`useLocalStorage` can not handle [batch updates](https://react.dev/learn/queueing-a-series-of-state-updates#updating-the-same-state-multiple-times-before-the-next-render) correctly, this PR will fix that.

It does not call the update function with the current state in the local storage.
It uses the last "rendered" state which will not work if you call the callback multiple times without react rendering the component between calls.

[Here is an example sandbox which shows our usecase.](https://codesandbox.io/p/devbox/romantic-torvalds-wfsy9q?file=%2Fsrc%2FTS.tsx%3A108%2C6&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clx92023600082v6ie0o7jeng%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clx92023500032v6iprlj48s2%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clx92023500052v6iriqlj35h%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clx92023500072v6ikjyz8mjj%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clx92023500032v6iprlj48s2%2522%253A%257B%2522id%2522%253A%2522clx92023500032v6iprlj48s2%2522%252C%2522activeTabId%2522%253A%2522clx92023400022v6i0y6ctq82%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clx92023400022v6i0y6ctq82%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252FTS.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A108%252C%2522startColumn%2522%253A6%252C%2522endLineNumber%2522%253A108%252C%2522endColumn%2522%253A6%257D%255D%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252F.codesandbox%252Ftasks.json%2522%252C%2522id%2522%253A%2522clx929aum00bm2v6izhn883c7%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522src%252FTS.tsx%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A73%252C%2522endLineNumber%2522%253A73%252C%2522startColumn%2522%253A19%252C%2522endColumn%2522%253A19%257D%255D%252C%2522id%2522%253A%2522clx92chtu00hu2v6imfndg7cc%2522%252C%2522mode%2522%253A%2522temporary%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%257D%252C%2522clx92023500072v6ikjyz8mjj%2522%253A%257B%2522id%2522%253A%2522clx92023500072v6ikjyz8mjj%2522%252C%2522activeTabId%2522%253A%2522clx92hno500z82v6i2ottbxdv%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TASK_PORT%2522%252C%2522port%2522%253A3001%252C%2522taskId%2522%253A%2522dev%2522%252C%2522id%2522%253A%2522clx92hno500z82v6i2ottbxdv%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522path%2522%253A%2522%252F%2522%257D%255D%257D%252C%2522clx92023500052v6iriqlj35h%2522%253A%257B%2522id%2522%253A%2522clx92023500052v6iriqlj35h%2522%252C%2522activeTabId%2522%253A%2522clx92hhc800xa2v6iu7rqlzsa%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522id%2522%253A%2522clx92hhc800xa2v6iu7rqlzsa%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

In this Menu top left of the app.
![image](https://github.com/uidotdev/usehooks/assets/6977872/0b966db6-8521-4c28-9411-e2547f2ac102)

If you Click show all or hide all this will do batch updates on the useLocalStorage which will only toggle the last column and not all columns due to this bug.
![image](https://github.com/uidotdev/usehooks/assets/6977872/06485524-4bbf-4450-b958-7dd3f04f632e)
