### PR TITLE
fix: (useCopyToClipboard): copyToClipboard should return promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ export function useCopyToClipboard() {
       }
     };
 
-    handleCopy();
+    return handleCopy();
   }, []);
 
   return [state, copyToClipboard];


### PR DESCRIPTION
Fixes #312

The copyToClipboard function is not returning a promise currently.  The intention (at least according to the function signature) is to fulfill the promise when the text is copied:
https://github.com/uidotdev/usehooks/blob/90fbbb4cc085e74e50c36a62a5759a40c62bb98e/index.d.ts#L126-L129

This PR will change the code to return a promise.  So the promise can fulfill when the text is copied successfully.
