### PR TITLE
Use superjson to parse/stringify objects instead of built in JSON's parse/stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 import * as React from "react";
+import superjson from 'superjson';
+
 
 function isShallowEqual(object1, object2) {
   const keys1 = Object.keys(object1);
@@ -590,7 +592,7 @@ export function useList(defaultList = []) {
 }
 
 const setLocalStorageItem = (key, value) => {
-  const stringifiedValue = JSON.stringify(value);
+  const stringifiedValue = superjson.stringify(value);
   window.localStorage.setItem(key, stringifiedValue);
   dispatchStorageEvent(key, stringifiedValue);
 };
@@ -625,7 +627,7 @@ export function useLocalStorage(key, initialValue) {
   const setState = React.useCallback(
     (v) => {
       try {
-        const nextState = typeof v === "function" ? v(JSON.parse(store)) : v;
+        const nextState = typeof v === "function" ? v(superjson.parse(store)) : v;
 
         if (nextState === undefined || nextState === null) {
           removeLocalStorageItem(key);
@@ -648,7 +650,7 @@ export function useLocalStorage(key, initialValue) {
     }
   }, [key, initialValue]);
 
-  return [store ? JSON.parse(store) : initialValue, setState];
+  return [store ? superjson.parse(store) : initialValue, setState];
 }
 
 export function useLockBodyScroll() {
@@ -1151,7 +1153,7 @@ export function useScript(src, options = {}) {
 }
 
 const setSessionStorageItem = (key, value) => {
-  const stringifiedValue = JSON.stringify(value);
+  const stringifiedValue = superjson.stringify(value);
   window.sessionStorage.setItem(key, stringifiedValue);
   dispatchStorageEvent(key, stringifiedValue);
 };
@@ -1186,7 +1188,7 @@ export function useSessionStorage(key, initialValue) {
   const setState = React.useCallback(
     (v) => {
       try {
-        const nextState = typeof v === "function" ? v(JSON.parse(store)) : v;
+        const nextState = typeof v === "function" ? v(superjson.parse(store)) : v;
 
         if (nextState === undefined || nextState === null) {
           removeSessionStorageItem(key);
@@ -1209,7 +1211,7 @@ export function useSessionStorage(key, initialValue) {
     }
   }, [key, initialValue]);
 
-  return [store ? JSON.parse(store) : initialValue, setState];
+  return [store ? superjson.parse(store) : initialValue, setState];
 }
 
 export function useSet(values) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
       },
       "peerDependencies": {
         "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react-dom": ">=18.0.0",
+        "superjson": "^2.2.1"
       }
     },
     "node_modules/@types/prop-types": {
@@ -45,11 +46,38 @@
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
       "dev": true
     },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "peer": true,
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
       "dev": true
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -101,6 +129,18 @@
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
+      "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+      "peer": true,
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@uidotdev/usehooks",
       "version": "2.4.1",
       "license": "MIT",
+      "dependencies": {
+        "superjson": "^2.2.1"
+      },
       "devDependencies": {
         "@types/react": "^18.2.20",
         "react": "^18.2.0",
@@ -19,8 +22,7 @@
       },
       "peerDependencies": {
         "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
-        "superjson": "^2.2.1"
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -50,7 +52,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
       "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
-      "peer": true,
       "dependencies": {
         "is-what": "^4.1.8"
       },
@@ -71,7 +72,6 @@
       "version": "4.1.16",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
       "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
-      "peer": true,
       "engines": {
         "node": ">=12.13"
       },
@@ -135,7 +135,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
       "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
   "types": "index.d.ts",
   "peerDependencies": {
     "react": ">=18.0.0",
-    "react-dom": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "dependencies": {
     "superjson": "^2.2.1"
+
   },
   "author": "Tyler McGinnis, Ben Adam",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "types": "index.d.ts",
   "peerDependencies": {
     "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react-dom": ">=18.0.0",
+    "superjson": "^2.2.1"
   },
   "author": "Tyler McGinnis, Ben Adam",
   "license": "MIT"


### PR DESCRIPTION
Replaced `JSON.stringify` and `JSON.parse ` to use [superjson](https://github.com/blitz-js/superjson) instead so we can parse objects such as maps and more that's not supported by default