### PR TITLE
add initial previous value param to usePrevious hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -1014,7 +1014,7 @@ export function usePreferredLanguage() {
   );
 }
 
-export function usePrevious(value) {
+export function usePrevious(value, initialPreviousValue) {
   const [current, setCurrent] = React.useState(value);
   const [previous, setPrevious] = React.useState(null);
 
@@ -1023,7 +1023,7 @@ export function usePrevious(value) {
     setCurrent(value);
   }
 
-  return previous;
+  return previous || initialPreviousValue;
 }
 
 export function useQueue(initialValue = []) {

--- a/usehooks.com/src/content/hooks/usePrevious.mdx
+++ b/usehooks.com/src/content/hooks/usePrevious.mdx
@@ -26,6 +26,7 @@ import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
   | Name     | Type | Description                                        |
   | -------- | ---- | -------------------------------------------------- |
   | newValue | any  | The new value to track and return the previous of. |
+  | initialValue | any  | (Optional) The initial Previous Value. Default value is null.
   </div>
 
   ### Return Value


### PR DESCRIPTION
## Summary
Add optional initial value parameter to usePrevious hook and fix typescript

- #275 
- #323 

## Reason
### 1. Performance Issue
The current implementation uses two useState hooks and updates state during render, which can cause unnecessary re-renders and violate React's rendering rules:
```javascript
const [current, setCurrent] = React.useState(value);
const [previous, setPrevious] = React.useState(null);
if (value !== current) { // State updates during render
  setPrevious(current);
  setCurrent(value);
}
```

### 2. Initial Value
The hook always returns null as the initial previous value, which causes issues in scenarios where a different initial value is needed:
```javascript
function MyTable({data, loading}) {
  const previousData = usePrevious(data); // Initially returns null
  // This throws an exception when loading is true
  const table = useReactTable({data: loading ? previousData : data}); 
}
```

### 3. Wrong Type
Current type definition doesn't accurately represent the hook's behavior:
```typescript
export function usePrevious<T>(newValue: T): T; // Current
export function usePrevious<T>(newValue: T): T | null; // Should be
```
