### PR TITLE
fix(types): correct default value for `useThrottle` delay parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -240,7 +240,7 @@ declare module "@uidotdev/usehooks" {
 
   export function useSpeech(text: string, options?: SpeechOptions): SpeechState;
 
-  export function useThrottle<T>(value: T, delay: number): T;
+  export function useThrottle<T>(value: T, delay = 500): T;
 
   export function useToggle(
     initialValue?: boolean


### PR DESCRIPTION
Previously, the TypeScript declaration for `useThrottle` did not reflect  the actual default value of the `delay` parameter. This fix ensures that  the default value (`500ms`) is correctly represented in the type definition.