### PR TITLE
FIx `useMap` type parameters to set value type as well

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ declare module "@uidotdev/usehooks" {
     options?: LongPressOptions
   ): LongPressFns;
 
-  export function useMap<T>(initialState?: T): Map<T, any>;
+  export function useMap<K,V>(initialState?: Iterable<readonly [K, V]> | null): Map<K, V>;
 
   export function useMeasure<T extends Element>(): [
     React.RefCallback<T>,


### PR DESCRIPTION
Currently `useMap` seems to have been copy-pasted from `useSet` and its type signature does not allow setting map value type, and the initialValues type is straight up incorrect.

This adds an extra type parameter for the value type, and makes the initialValues type match the type of the map constructor type


Fixes #365 