### PR TITLE
Fix useObjectState type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -207,7 +207,7 @@ declare module "@uidotdev/usehooks" {
 
   export function useNetworkState(): NetworkState;
 
-  export function useObjectState<T>(initialValue: T): [T, (arg: T) => void];
+  export function useObjectState<T>(initialValue: T): [T, (arg: T | ((arg: (arg: T) => Partial<T>) => void)) => void];
 
   export function useOrientation(): {
     angle: number;


### PR DESCRIPTION
The [example](https://usehooks.com/useobjectstate) provided doesn't work. The setter can take either the object or a function but the type only allows the object.

```ts
    setStats((s) => ({
      wins: s.wins + 1,
    }));
 ```