### PR TITLE
Add missing return statement to copyToClipboard util

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ export function useCopyToClipboard() {
       }
     };
 
-    handleCopy();
+    return handleCopy();
   }, []);
 
   return [state, copyToClipboard];


### PR DESCRIPTION
While using the `useCopyToClipboard` hook I noticed that the 2nd argument returned by the hook (the `copyToClipboard` callback) does not match the typescript signature.
https://github.com/uidotdev/usehooks/blob/945436df0037bc21133379a5e13f1bd73f1ffc36/index.d.ts#L126-L129

By adding a `return` before the `handleCopy` function call, the callback now returns the promise, which now allows you to chain a `.then()` and `.catch()` to it, while previously it used to throw

<img width="1112" height="228" alt="image" src="https://github.com/user-attachments/assets/2fc4e1b5-61a1-4fa1-8441-d63460870f02" />
