### PR TITLE
feat: Add multi-format clipboard support to useCopyToClipboard 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,6 +116,12 @@ export type SpeechState = {
   volume: number;
 };
 
+export type ClipboardFormats = {
+  plain?: string;
+  html?: string;
+  markdown?: string;
+};
+
 declare module "@uidotdev/usehooks" {
   export function useBattery(): BatteryManager;
 
@@ -125,7 +131,7 @@ declare module "@uidotdev/usehooks" {
 
   export function useCopyToClipboard(): [
     string | null,
-    (value: string) => Promise<void>
+    (value: string | ClipboardFormats) => Promise<void>
   ];
 
   export function useCounter(

--- a/index.js
+++ b/index.js
@@ -145,18 +145,32 @@ export function useCopyToClipboard() {
   const copyToClipboard = React.useCallback((value) => {
     const handleCopy = async () => {
       try {
-        if (navigator?.clipboard?.writeText) {
+        // ClipboardItem API for multiple formats
+        if (typeof value === 'object' && value !== null && window.ClipboardItem) {
+          const items = {};
+          if (value.plain) {
+            items["text/plain"] = new Blob([value.plain], { type: "text/plain" });
+          }
+          if (value.html) {
+            items["text/html"] = new Blob([value.html], { type: "text/html" });
+          }
+          if (value.markdown) {
+            items["text/markdown"] = new Blob([value.markdown], { type: "text/markdown" });
+          }
+          const clipboardItem = new ClipboardItem(items);
+          await navigator.clipboard.write([clipboardItem]);
+          setState(value.plain || value.html || value.markdown);
+        } else if (navigator?.clipboard?.writeText) {
           await navigator.clipboard.writeText(value);
           setState(value);
         } else {
           throw new Error("writeText not supported");
         }
       } catch (e) {
-        oldSchoolCopy(value);
-        setState(value);
+        oldSchoolCopy(typeof value === 'object' ? value.plain : value);
+        setState(typeof value === 'object' ? value.plain : value);
       }
     };
-
     handleCopy();
   }, []);
 


### PR DESCRIPTION
## Description

This PR updates the `useCopyToClipboard` hook to support copying multiple clipboard formats (plain text, HTML, and Markdown) using the modern `ClipboardItem` API.

## Resolves

Resolves #329

## Changes

### Core Implementation
- Enhanced `useCopyToClipboard` to accept either a string or an object with multiple format properties (`plain`, `html`, `markdown`)
- Implemented `ClipboardItem` API support for copying multiple formats simultaneously
- Maintained backward compatibility - existing usage with plain strings continues to work
- Added proper fallback handling for browsers that don't support `ClipboardItem`

### Type Definitions
- Added new `ClipboardFormats` type to `index.d.ts` with optional properties for different formats
- Updated function signature to accept `string | ClipboardFormats`

## Benefits

- Enables copying rich content (HTML formatting, Markdown) to clipboard
- Applications can provide formatted content that preserves styling when pasted
- No breaking changes - fully backward compatible
- Better user experience with multiple paste format options