### PR TITLE
Add useCookieStorage hook for React state synchronization with browser cookies

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,14 @@ export type CustomQueue<T> = {
   queue: T[];
 };
 
+export type CookieOptions = {
+  /** Number of days from now or a Date object */
+  expires?: number | Date;
+  path?: string;
+  sameSite?: "Lax" | "Strict" | "None";
+  secure?: boolean;
+};
+
 export type RenderInfo = {
   name: string;
   renders: number;
@@ -179,6 +187,12 @@ declare module "@uidotdev/usehooks" {
   export function useLocalStorage<T>(
     key: string,
     initialValue?: T
+  ): [T, React.Dispatch<React.SetStateAction<T>>];
+
+  export function useCookieStorage<T>(
+    key: string,
+    initialValue?: T,
+    options?: CookieOptions
   ): [T, React.Dispatch<React.SetStateAction<T>>];
 
   export function useLockBodyScroll(): void;


### PR DESCRIPTION
## Overview

This PR adds a new hook called `useCookieStorage` to enable React state synchronization with browser cookies.

## Features

- **Reading/Writing JSON Values**: Automatically serializes and deserializes values as JSON
- **Type-Safe CookieOptions**: Supports configurable cookie options including:
  - `expires`: Number of days from now or a Date object (default: 365 days)
  - `path`: Cookie path (default: '/')
  - `sameSite`: SameSite attribute ('Lax', 'Strict', or 'None', default: 'Lax')
  - `secure`: Secure flag for HTTPS-only cookies (default: false)
- **Initial Default Value**: Allows setting an initial value when the cookie doesn't exist
- **Automatic Reactivity**: Uses `useSyncExternalStore` for cross-tab updates, ensuring state synchronization across browser tabs

## Related Issue

Resolves #272