### PR TITLE
feat(useFavicon): add temporary option to restore favicon on unmount

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,12 @@ declare module "@uidotdev/usehooks" {
 
   export function useDocumentTitle(title: string): void;
 
-  export function useFavicon(url: string): void;
+  export function useFavicon(
+    url: string,
+    options?: {
+      temporary?: boolean;
+    }
+  ): void;
 
   export function useGeolocation(options?: PositionOptions): GeolocationState;
 

--- a/index.js
+++ b/index.js
@@ -268,18 +268,34 @@ export function useDocumentTitle(title) {
   }, [title]);
 }
 
-export function useFavicon(url) {
+export function useFavicon(url, options = {}) {
+  const optionsRef = React.useRef(options);
+
   React.useEffect(() => {
     let link = document.querySelector(`link[rel~="icon"]`);
+    let created = false;
 
     if (!link) {
       link = document.createElement("link");
       link.type = "image/x-icon";
       link.rel = "icon";
-      link.href = url;
       document.head.appendChild(link);
-    } else {
-      link.href = url;
+      created = true;
+    }
+
+    const original = link.href;
+    link.href = url;
+
+    const { temporary } = optionsRef.current;
+
+    if (temporary) {
+      return () => {
+        if (created) {
+          link.remove();
+        } else {
+          link.href = original;
+        }
+      };
     }
   }, [url]);
 }

--- a/usehooks.com/src/content/hooks/useFavicon.mdx
+++ b/usehooks.com/src/content/hooks/useFavicon.mdx
@@ -13,16 +13,17 @@ import HookDescription from "../../components/HookDescription.astro";
 import StaticCodeContainer from "../../components/StaticCodeContainer.astro";
 
 <HookDescription name={frontmatter.name}>
-  The useFavicon hook is a useful for dynamically update the favicon (shortcut icon) of a web page. By using this hook, you can easily change the favicon by providing a new URL as a parameter. It creates a new link element with the specified URL, sets its type and relationship attributes appropriately, and appends it to the `<head>` section of the document.
+  The useFavicon hook is useful for dynamically updating the favicon (shortcut icon) of a web page. By using this hook, you can easily change the favicon by providing a new URL as a parameter. It creates a new link element with the specified URL, sets its type and relationship attributes appropriately, and appends it to the `<head>` section of the document. Optionally, you can pass `{ temporary: true }` to automatically restore the original favicon when the component unmounts.
 </HookDescription>
 
 <div class="reference">
   ### Parameters
 
   <div class="table-container">
-  | Name | Type   | Description                                        |
-  | ---- | ------ | -------------------------------------------------- |
-  | url  | string | The URL of the favicon to be set for the document. |
+  | Name    | Type   | Description                                        |
+  | ------- | ------ | -------------------------------------------------- |
+  | url     | string | The URL of the favicon to be set for the document. |
+  | options | object | This is an optional configuration object provided when calling `useFavicon`. It currently accepts one property `temporary` which when set to `true`, will restore the original favicon on component unmount. |
   </div>
 </div>
 


### PR DESCRIPTION
**Feature Request: Support temporary favicon with cleanup on unmount**

**Current behavior**

`useFavicon` sets the favicon but never restores the original when the component unmounts, making it impossible to use it temporarily on a specific page or component.

**Proposed API**

Add an optional `options` parameter with a `temporary` flag:

```ts
useFavicon(url, { temporary: true });
```

**Notes on implementation**

- `options` is stored in a ref (following the same pattern as `useScript`) so changes to the options object don't cause the effect to re-run unnecessarily.
- If no `link[rel~="icon"]` exists in the document (e.g. frameworks that only use a `preload` hint instead of an icon link), the hook creates one and **removes** it on cleanup rather than restoring an empty `href`. This handles environments like TanStack Start correctly.
- If the link already existed, the original `href` is restored as expected.

**Use case**

Setting a page-specific favicon that should revert to the app's default favicon when navigating away.

```ts
// Reverts to original favicon when component unmounts
useFavicon("https://example.com/favicon.ico", { temporary: true });
```